### PR TITLE
Fix for build errors

### DIFF
--- a/app/actionBar/actionBar.ts
+++ b/app/actionBar/actionBar.ts
@@ -16,5 +16,4 @@ export function onLoad(args: EventData) {
 
 	actionBarTitle.text = page.ActionBarTitle;
 
-	page.bindingContext = new NavigationViewModel(page);
 }


### PR DESCRIPTION
was passing instead of the page an instance of the action bar. which
was causing the application to blow up.
